### PR TITLE
Use classes instead of ids for repeated components

### DIFF
--- a/components/byu-story/byu-story-extras.scss
+++ b/components/byu-story/byu-story-extras.scss
@@ -18,14 +18,14 @@
 @import 'byu-story-common';
 
 // -------- VARIABLE CSS ------- //
-#title-slot-wrapper h3 {
+.title-slot-wrapper h3 {
   @include storyTitleStyle();
 }
 
-#title-slot-wrapper h3:hover {
+.title-slot-wrapper h3:hover {
   @include linkHover();
 }
 
-#description-slot-wrapper p {
+.description-slot-wrapper p {
   @include storyTeaserStyle();
 }

--- a/components/byu-story/byu-story.html
+++ b/components/byu-story/byu-story.html
@@ -20,24 +20,24 @@
 </style>
 
 <div class="root story-root">
-  <div id="image-slot-wrapper">
+  <div class="image-slot-wrapper">
     <a class="story-link" href="">
       <slot name="story-image"></slot>
     </a>
   </div>
   <div class="region-right">
-    <div id="category-slot-wrapper">
+    <div class="category-slot-wrapper">
       <slot name="story-category"></slot>
     </div>
-    <div id="title-slot-wrapper">
+    <div class="title-slot-wrapper">
       <a class="story-link" href="">
         <slot name="story-title"></slot>
       </a>
     </div>
-    <div id="description-slot-wrapper">
+    <div class="description-slot-wrapper">
       <slot name="story-teaser"></slot>
     </div>
-    <div id="date-slot-wrapper">
+    <div class="date-slot-wrapper">
       <slot name="story-date"></slot>
     </div>
   </div>

--- a/components/byu-story/byu-story.js
+++ b/components/byu-story/byu-story.js
@@ -133,7 +133,7 @@ function getStoryData(component) {
       storyLinks[1].replaceChild(storyTitle, replaceSlot);
 
       if (component.showCategory == '') {
-        let categoryWrapper = component.shadowRoot.querySelector('#category-slot-wrapper');
+        let categoryWrapper = component.shadowRoot.querySelector('.category-slot-wrapper');
 
         let storyCategory = document.createElement("span");
         replaceSlot = categoryWrapper.firstChild;
@@ -143,7 +143,7 @@ function getStoryData(component) {
       }
 
       if (component.showDate == '') {
-        let dateWrapper = component.shadowRoot.querySelector('#date-slot-wrapper');
+        let dateWrapper = component.shadowRoot.querySelector('.date-slot-wrapper');
         let date = story[0].datePublished;
         date = date.replace('-', '. ');
         date = date.replace('-', ', ');
@@ -170,7 +170,7 @@ function getStoryData(component) {
           teaser = teaser.replace(/\W*\s(\S)*$/, '...');
         }
 
-        let descriptionWrapper = component.shadowRoot.querySelector('#description-slot-wrapper');
+        let descriptionWrapper = component.shadowRoot.querySelector('.description-slot-wrapper');
 
         let storyDescription = document.createElement("p");
         replaceSlot = descriptionWrapper.firstChild;
@@ -181,7 +181,7 @@ function getStoryData(component) {
       }
       else {
         let body = story[0].Body;
-        let descriptionWrapper = component.shadowRoot.querySelector('#description-slot-wrapper');
+        let descriptionWrapper = component.shadowRoot.querySelector('.description-slot-wrapper');
 
         let storyDescription = document.createElement("p");
         replaceSlot = descriptionWrapper.firstChild;

--- a/components/byu-story/byu-story.scss
+++ b/components/byu-story/byu-story.scss
@@ -39,7 +39,7 @@
   @include regionRight();
 }
 
-#title-slot-wrapper {
+.title-slot-wrapper {
   a {
     @include linkDefault();
   }
@@ -55,21 +55,21 @@
   @include storyBody();
 }
 
-#title-slot-wrapper {
+.title-slot-wrapper {
   a:hover {
     @include linkHover();
   }
 }
 
-#description-slot-wrapper, p {
+.description-slot-wrapper, p {
   @include descriptionSlotted();
 }
 
-#category-slot-wrapper {
+.category-slot-wrapper {
   @include categorySlotted();
 }
 
-#date-slot-wrapper {
+.date-slot-wrapper {
   @include dateSlotted();
 }
 
@@ -100,7 +100,7 @@
     }
   }
 
-  #description-slot-wrapper {
+  .description-slot-wrapper {
     ::slotted(.story-teaser) {
       @include descriptionMobile();
     }
@@ -110,7 +110,7 @@
     @include descriptionMobile();
   }
 
-  #date-slot-wrapper {
+  .date-slot-wrapper {
     @include mobileDateSlotted();
   }
 }
@@ -147,7 +147,7 @@
     }
   }
 
-  #description-slot-wrapper {
+  .description-slot-wrapper {
     ::slotted(.story-teaser) {
       @include descriptionMobile();
     }
@@ -157,16 +157,16 @@
     @include descriptionMobile();
   }
 
-  #date-slot-wrapper {
+  .date-slot-wrapper {
     @include mobileDateSlotted();
   }
 }
 
 // -------- VARIABLE CSS ------- //
-#title-slot-wrapper, #title-slot-wrapper h3 {
+.title-slot-wrapper, .title-slot-wrapper h3 {
   @include storyTitleStyle();
 }
 
-#description-slot-wrapper, #description-slot-wrapper p {
+.description-slot-wrapper, .description-slot-wrapper p {
   @include storyTeaserStyle();
 }


### PR DESCRIPTION
# Summary of Changes

**Fixes Issue #(Add issue number here)**

*What did you change? If this is a bug fix, how did you fix it?*
Changed all IDs being used for styling into classes, as they were being duplicated with each extra component. [Non-unique IDs in HTML are discouraged.](https://softwareengineering.stackexchange.com/questions/127178/two-html-elements-with-same-id-attribute-how-bad-is-it-really)

**If this fixes styling, please include before and after screenshots!**

# Browser Testing

**I have tested these changes in:**

*Add an x in all the boxes that apply. Please mark desktop and mobile
browsers separately.*

## Desktop Browsers

- [x] Google Chrome
- [x] Mozilla Firefox
- [x] Apple Safari
- [ ] Microsoft Edge
- [ ] Microsoft Internet Explorer 11
- [ ] Other (please specify)

## Mobile Browsers

- [ ] Any browser on iOS
- [ ] Chrome for Android
- [ ] Firefox Mobile for Android
- [ ] Other (please specify)

**We support the last two versions of Chrome, Firefox, Safari, and Edge,
plus Internet Explorer 11.**
