### PR TITLE
Remove category element when display disabled. Fixes #41

### DIFF
--- a/components/byu-story/byu-story.js
+++ b/components/byu-story/byu-story.js
@@ -106,6 +106,11 @@ function getStoryData(component) {
     for (let i = 0; i < links.length; i++) {
       links[i].setAttribute('href', NEWS_SITE + component.storyId);
     }
+
+    if (component.showCategory != '') {
+      // Remove the category element if it is unused
+      component.shadowRoot.querySelector('#category-slot-wrapper').remove();
+    }
   }
   else {
     let url = ENDPOINT + 'Story?_format=json&id=' + component.storyId;
@@ -132,14 +137,16 @@ function getStoryData(component) {
       storyTitle.innerHTML = story[0].Title;
       storyLinks[1].replaceChild(storyTitle, replaceSlot);
 
+      let categoryWrapper = component.shadowRoot.querySelector('#category-slot-wrapper');
       if (component.showCategory == '') {
-        let categoryWrapper = component.shadowRoot.querySelector('#category-slot-wrapper');
-
         let storyCategory = document.createElement("span");
         replaceSlot = categoryWrapper.firstChild;
         storyCategory.setAttribute('class', 'story-category');
         storyCategory.innerHTML = story[0].Category;
         categoryWrapper.replaceChild(storyCategory, replaceSlot);
+      } else {
+        // Remove the category element if it is unused
+        categoryWrapper.remove();
       }
 
       if (component.showDate == '') {


### PR DESCRIPTION
# Summary of Changes

**Fixes Issue #41**

*What did you change? If this is a bug fix, how did you fix it?*
Remove the category element when category display is enabled.

**If this fixes styling, please include before and after screenshots!**
Before: ![before](https://user-images.githubusercontent.com/4413963/47256517-b925c300-d4bc-11e8-8a6c-1641f343953f.png)
After: ![after](https://user-images.githubusercontent.com/4413963/47256518-bb881d00-d4bc-11e8-899d-fe1a658c2583.png)

# Browser Testing

**I have tested these changes in:**

*Add an x in all the boxes that apply. Please mark desktop and mobile
browsers separately.*

## Desktop Browsers

- [x] Google Chrome
- [x] Mozilla Firefox
- [x] Apple Safari
- [ ] Microsoft Edge
- [ ] Microsoft Internet Explorer 11
- [ ] Other (please specify)

## Mobile Browsers

- [ ] Any browser on iOS
- [ ] Chrome for Android
- [ ] Firefox Mobile for Android
- [ ] Other (please specify)

**We support the last two versions of Chrome, Firefox, Safari, and Edge,
plus Internet Explorer 11.**
